### PR TITLE
翻訳者向けのコメントが speechSynth の説明になっていたので修正

### DIFF
--- a/addon/globalPlugins/dokutor_for_nvda.py
+++ b/addon/globalPlugins/dokutor_for_nvda.py
@@ -25,7 +25,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			self.clear()
 		else:
 			self.load()
-	#Translators: Input help mode message for set synth command.
+	#Translators: Input help mode message for change dict command.
 	script_changeDict.__doc__ = _("理療科用読み辞書の適用状態を切り替える")
 
 	def load(self):


### PR DESCRIPTION
日本語版前提なので、消してしまってもいいと思ったけれど、一応。