### PR TITLE
アドオンの terminate でエラーが起きていたのを修正

### DIFF
--- a/addon/globalPlugins/dokutor_for_nvda/__init__.py
+++ b/addon/globalPlugins/dokutor_for_nvda/__init__.py
@@ -58,7 +58,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
     def terminate(self):
         super(GlobalPlugin, self).terminate()
-        lgc.freeHissdll()
         try:
             gui.mainFrame.sysTrayIcon.menu.Remove(self.rootMenuItem)
         except BaseException:


### PR DESCRIPTION
定義されていない関数が呼ばれており、アドオンの `__terminate__` の箇所でエラーが起きていたのを修正しました。
