### PR TITLE
readme の脱字修正

### DIFF
--- a/public/readme.txt
+++ b/public/readme.txt
@@ -156,7 +156,7 @@ ACT Laboratory(Accessible Tools Laboratory)は、プログラミングを学ぶ�
 * 1.1.0 (2022/04/X)
     * NVDA 2022.1に対応
     * アップデーターを搭載
-    * NVDメニューからの操作に対応
+    * NVDAメニューからの操作に対応
     * NVDA起動時の読み辞書の状態を切り替える設定を追加
 
 

--- a/readme.md
+++ b/readme.md
@@ -156,7 +156,7 @@ ACT Laboratory(Accessible Tools Laboratory)は、プログラミングを学ぶ�
 * 1.1.0 (2022/04/X)
     * NVDA 2022.1に対応
     * アップデーターを搭載
-    * NVDメニューからの操作に対応
+    * NVDAメニューからの操作に対応
     * NVDA起動時の読み辞書の状態を切り替える設定を追加
 
 


### PR DESCRIPTION
readme の更新履歴の箇所で「NVDAメニュー」が「NVDメニュー」になっていたので修正しました。
